### PR TITLE
Query limits on large datasets

### DIFF
--- a/explorer/views.py
+++ b/explorer/views.py
@@ -397,7 +397,7 @@ def query_viewmodel(user, query, title=None, form=None, message=None, run_query=
         'rows': rows,
         'data': res.data[:rows] if has_valid_results else None,
         'headers': res.headers if has_valid_results else None,
-        'total_rows': len(res.data) if has_valid_results else None,
+        'total_rows': res.row_count if has_valid_results else None,
         'duration': res.duration if has_valid_results else None,
         'has_stats': len([h for h in res.headers if h.summary]) if has_valid_results else False,
         'snapshots': query.snapshots if query.snapshot else [],


### PR DESCRIPTION
This introduces limits on queries that take place on large datasets.

It wraps the request in a server side cursor and fetches the limit which is set by the setting `EXPLORER_DEFAULT_ROWS` defaults to 1000


The implementation is not perfect and there are a few things to look at in future PRs
 - The execute_query func would ideally not be called from  __init__
- Serverside query only used when db is postrges
- Any DB errors will include information about the cursor used and ideally this should be hidden from the end user
- Initially the query was moved inside a transaction atomic block but this caused issues with the sqllite tests so it has been removed for now and will be something to monitor whilst testing.
- Scope to refactor model classes as they feel abit messy but this is a good start.


Example large query on world tariff L0 (80 mill rows) - takes just under a min to return limited results when limit has not been specified on the query.

<img width="1193" alt="Screenshot 2020-04-30 at 11 23 52" src="https://user-images.githubusercontent.com/8222658/80700826-44324100-8ad6-11ea-89bf-932fbd346f97.png">


To test within your local data explorer 
`pip install -U git+https://github.com/uktrade/django-sql-explorer.git@fix/limit`




