### PR TITLE
Redirect to query view if download fails

### DIFF
--- a/explorer/__init__.py
+++ b/explorer/__init__.py
@@ -1,4 +1,4 @@
-__version_info__ = {'major': 1, 'minor': 1, 'micro': 3, 'releaselevel': 'final', 'serial': 0}
+__version_info__ = {'major': 1, 'minor': 1, 'micro': 4, 'releaselevel': 'final', 'serial': 0}
 
 
 def get_version(short=False):

--- a/explorer/tests/test_views.py
+++ b/explorer/tests/test_views.py
@@ -303,13 +303,14 @@ class TestDownloadView(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['content-type'], 'text/csv')
 
-    def test_bad_query_gives_500(self):
+    def test_bad_query_redirects_to_query_view(self):
         query = SimpleQueryFactory(sql='bad')
         url = reverse("download_query", args=[query.pk]) + '?format=csv'
 
         response = self.client.get(url)
 
-        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, f'/{query.pk}/')
 
     def test_download_json(self):
         query = SimpleQueryFactory()

--- a/explorer/views.py
+++ b/explorer/views.py
@@ -118,7 +118,10 @@ class DownloadQueryView(PermissionRequiredMixin, View):
 
     def get(self, request, query_id, *args, **kwargs):
         query = get_object_or_404(Query, pk=query_id)
-        return _export(request, query)
+        resp = _export(request, query)
+        if isinstance(resp, HttpResponse) and resp.status_code == 500 and "Error executing query" in resp.content.decode(resp.charset):
+            return HttpResponseRedirect(reverse_lazy('query_detail', kwargs={'query_id': query_id}))
+        return resp
 
 
 class DownloadFromSqlView(PermissionRequiredMixin, View):


### PR DESCRIPTION
The error page for when a query download failures is just a line of text
on a blank page. To provide a more graceful failure state, we detect
this case and redirect to the query view, which shows the same error in
a styled error box.