### PR TITLE
Show user's email instead of UUID

### DIFF
--- a/explorer/__init__.py
+++ b/explorer/__init__.py
@@ -1,4 +1,4 @@
-__version_info__ = {'major': 1, 'minor': 1, 'micro': 4, 'releaselevel': 'final', 'serial': 0}
+__version_info__ = {'major': 1, 'minor': 1, 'micro': 5, 'releaselevel': 'final', 'serial': 0}
 
 
 def get_version(short=False):

--- a/explorer/tests/test_views.py
+++ b/explorer/tests/test_views.py
@@ -168,7 +168,7 @@ class TestQueryDetailView(TestCase):
         with self.settings(EXPLORER_TOKEN_AUTH_ENABLED=True):
             resp = self.client.get(
                 reverse("query_detail", kwargs={'query_id': query.id}),
-                **{'HTTP_X_API_TOKEN': EXPLORER_TOKEN}
+                **{'HTTP_X_API_TOKEN': EXPLORER_TOKEN},
             )
         self.assertTemplateUsed(resp, 'explorer/query.html')
         self.assertContains(resp, "124")

--- a/explorer/views.py
+++ b/explorer/views.py
@@ -119,7 +119,11 @@ class DownloadQueryView(PermissionRequiredMixin, View):
     def get(self, request, query_id, *args, **kwargs):
         query = get_object_or_404(Query, pk=query_id)
         resp = _export(request, query)
-        if isinstance(resp, HttpResponse) and resp.status_code == 500 and "Error executing query" in resp.content.decode(resp.charset):
+        if (
+            isinstance(resp, HttpResponse)
+            and resp.status_code == 500
+            and "Error executing query" in resp.content.decode(resp.charset)
+        ):
             return HttpResponseRedirect(reverse_lazy('query_detail', kwargs={'query_id': query_id}))
         return resp
 
@@ -259,11 +263,12 @@ class ListQueryView(PermissionRequiredMixin, ExplorerContextMixin, ListView):
                     'created_at': q.created_at,
                     'is_header': False,
                     'run_count': q.run_count,
-                    'created_by_user': six.text_type(q.created_by_user)
+                    'created_by_user': six.text_type(q.created_by_user.email)
                     if q.created_by_user
                     else None,
                 }
             )
+
             dict_list.append(model_dict)
         return dict_list
 


### PR DESCRIPTION
https://trello.com/c/MViADShv/415-display-users-name-instead-of-uuid-in-the-playground-table

Note: Some minor unrelated changes due to formatting.