### PR TITLE
Flag up whole words only when checking blacklist/whitelist

### DIFF
--- a/explorer/tests/test_utils.py
+++ b/explorer/tests/test_utils.py
@@ -48,6 +48,12 @@ class TestSqlBlacklist(TestCase):
         self.assertEqual(words[0], 'DROP')
         self.assertEqual(words[1], 'DELETE')
 
+    def test_blacklist_only_works_with_whole_words(self):
+        # This contains the word alter but should not be flagged
+        sql = "SELECT alternative from table;"
+        passes, words = passes_blacklist(sql)
+        self.assertTrue(passes)
+
     def test_queries_dropping_views_is_not_ok_and_not_case_sensitive(self):
         sql = "SELECT 1+1 AS TWO; drop ViEw foo;"
         self.assertFalse(passes_blacklist(sql)[0])

--- a/explorer/utils.py
+++ b/explorer/utils.py
@@ -18,7 +18,12 @@ def passes_blacklist(sql):
         [t.upper() for t in app_settings.EXPLORER_SQL_WHITELIST],
         sql,
     )
-    fails = [bl_word for bl_word in app_settings.EXPLORER_SQL_BLACKLIST if bl_word in clean.upper()]
+    all_words_regex = r'\b\S+\b'
+    fails = [
+        bl_word
+        for bl_word in app_settings.EXPLORER_SQL_BLACKLIST
+        if bl_word in re.findall(all_words_regex, clean)
+    ]
     return not any(fails), fails
 
 


### PR DESCRIPTION
This stops queries that contain words like "Alternative" getting flagged for containing the blacklist word "ALTER"