### PR TITLE
Only show tables the DB user can access

### DIFF
--- a/explorer/tests/test_schema.py
+++ b/explorer/tests/test_schema.py
@@ -7,6 +7,8 @@ from explorer.app_settings import EXPLORER_CONNECTIONS
 
 
 class TestSchemaInfo(TestCase):
+    databases = ['postgres']
+
     @patch('explorer.schema._get_includes')
     @patch('explorer.schema._get_excludes')
     def test_schema_info_returns_valid_data(self, mocked_excludes, mocked_includes):

--- a/explorer/tests/test_views.py
+++ b/explorer/tests/test_views.py
@@ -489,6 +489,8 @@ class TestSQLDownloadViews(TestCase):
 
 
 class TestSchemaView(TestCase):
+    databases = ['default', 'postgres']
+
     def setUp(self):
         cache.clear()
         self.user = User.objects.create_superuser('admin', 'admin@admin.com', 'pwd')


### PR DESCRIPTION
We make a lot of use of per-user schemas and have a lot of tables that
users can't access, so listing all schemas/tables makes the Data
Explorer fairly unfriendly to use. Let's read the information schema,
which respects the permissions of the database connection, to only show
tables that the connection can access.

Ticket: https://trello.com/c/3xtk3A38/590-show-only-permitted-tables-exclude-personal-schemas-etc