### PR TITLE
Remove blacklist/whitelist and validate to ensure its a select query

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,11 +66,6 @@ Features
       execute queries. Other users cannot access any part of
       Explorer. Both permission groups are set to is_staff by default
       and can be overridden in your settings file.
-    - Enforces a SQL blacklist so destructive queries don't get
-      executed (delete, drop, alter, update etc). This is not
-      bulletproof and it's recommended that you instead configure a
-      read-only database role, but when not possible the blacklist
-      provides reasonable protection.
 - **Easy to get started**
     - Built on Django's ORM, so works with Postgresql, Mysql, and
       Sqlite. And, between you and me, it works fine on RedShift as
@@ -362,8 +357,6 @@ Settings
 ======================================= =============================================================================================================== ================================================================================================================================================
 Setting                                 Description                                                                                                                                                  Default
 ======================================= =============================================================================================================== ================================================================================================================================================
-EXPLORER_SQL_BLACKLIST                  Disallowed words in SQL queries to prevent destructive actions.                                                 ('ALTER', 'RENAME ', 'DROP', 'TRUNCATE', 'INSERT INTO', 'UPDATE', 'REPLACE', 'DELETE', 'ALTER', 'CREATE TABLE', 'SCHEMA', 'GRANT', 'OWNER TO')
-EXPLORER_SQL_WHITELIST                  These phrases are allowed, even though part of the phrase appears in the blacklist.                             ('CREATED', 'UPDATED', 'DELETED','REGEXP_REPLACE')
 EXPLORER_DEFAULT_ROWS                   The number of rows to show by default in the preview pane.                                                      1000
 EXPLORER_SCHEMA_INCLUDE_TABLE_PREFIXES  If not None, show schema only for tables starting with these prefixes. "Wins" if in conflict with EXCLUDE       None  # shows all tables
 EXPLORER_SCHEMA_EXCLUDE_TABLE_PREFIXES  Don't show schema for tables starting with these prefixes, in the schema helper.                                ('django.contrib.auth', 'django.contrib.contenttypes', 'django.contrib.sessions', 'django.contrib.admin')

--- a/explorer/actions.py
+++ b/explorer/actions.py
@@ -11,8 +11,7 @@ from explorer.exporters import CSVExporter
 
 def generate_report_action(description="Generate CSV file from SQL query"):
     def generate_report(modeladmin, request, queryset):
-        results = [report for report in queryset if report.passes_blacklist()[0]]
-        queries = (len(results) > 0 and _package(results)) or defaultdict(int)
+        queries = (len(queryset) > 0 and _package(queryset)) or defaultdict(int)
         response = HttpResponse(queries["data"], content_type=queries["content_type"])
         response['Content-Disposition'] = queries["filename"]
         response['Content-Length'] = queries["length"]

--- a/explorer/app_settings.py
+++ b/explorer/app_settings.py
@@ -11,29 +11,6 @@ from django.conf import settings
 EXPLORER_CONNECTIONS = getattr(settings, 'EXPLORER_CONNECTIONS', {})
 EXPLORER_DEFAULT_CONNECTION = getattr(settings, 'EXPLORER_DEFAULT_CONNECTION', None)
 
-# Change the behavior of explorer
-EXPLORER_SQL_BLACKLIST = getattr(
-    settings,
-    'EXPLORER_SQL_BLACKLIST',
-    (
-        'ALTER',
-        'RENAME ',
-        'DROP',
-        'TRUNCATE',
-        'INSERT INTO',
-        'UPDATE',
-        'REPLACE',
-        'DELETE',
-        'CREATE TABLE',
-        'GRANT',
-        'OWNER TO',
-    ),
-)
-
-EXPLORER_SQL_WHITELIST = getattr(
-    settings, 'EXPLORER_SQL_WHITELIST', ('CREATED', 'UPDATED', 'DELETED', 'REGEXP_REPLACE')
-)
-
 EXPLORER_DEFAULT_ROWS = getattr(settings, 'EXPLORER_DEFAULT_ROWS', 1000)
 EXPLORER_QUERY_TIMEOUT_MS = getattr(settings, 'EXPLORER_QUERY_TIMEOUT_MS', 60000)
 EXPLORER_DEFAULT_DOWNLOAD_ROWS = getattr(settings, 'EXPLORER_DEFAULT_DOWNLOAD_ROWS', 1000)

--- a/explorer/forms.py
+++ b/explorer/forms.py
@@ -2,25 +2,13 @@ from django.forms import BooleanField, CharField, Field, ModelForm, ValidationEr
 from django.forms.widgets import CheckboxInput, Select
 
 from explorer.app_settings import EXPLORER_CONNECTIONS, EXPLORER_DEFAULT_CONNECTION
-from explorer.models import MSG_FAILED_BLACKLIST, Query
+from explorer.models import Query
 
 
 class SqlField(Field):
     def validate(self, value):
-        """
-        Ensure that the SQL passes the blacklist.
-
-        :param value: The SQL for this Query model.
-        """
-
-        query = Query(sql=value)
-
-        passes_blacklist, failing_words = query.passes_blacklist()
-
-        error = MSG_FAILED_BLACKLIST % ', '.join(failing_words) if not passes_blacklist else None
-
-        if error:
-            raise ValidationError(error, code="InvalidSql")
+        if not value.upper().startswith("SELECT"):
+            raise ValidationError("Only SELECT statements are supported", code="InvalidSql")
 
 
 class QueryForm(ModelForm):

--- a/explorer/models.py
+++ b/explorer/models.py
@@ -20,12 +20,10 @@ from explorer.utils import (
     get_params_for_url,
     get_s3_bucket,
     get_valid_connection,
-    passes_blacklist,
     shared_dict_update,
     swap_params,
 )
 
-MSG_FAILED_BLACKLIST = "Query failed the SQL blacklist: %s"
 POSTGRES_VENDOR = 'postgresql'
 
 logger = logging.getLogger(__name__)
@@ -67,9 +65,6 @@ class Query(models.Model):
 
     def avg_duration(self):
         return self.querylog_set.aggregate(models.Avg('duration'))['duration__avg']
-
-    def passes_blacklist(self):
-        return passes_blacklist(self.final_sql())
 
     def final_sql(self):
         return swap_params(self.sql, self.available_params())

--- a/explorer/tests/test_forms.py
+++ b/explorer/tests/test_forms.py
@@ -11,7 +11,7 @@ class TestFormValidation(TestCase):
         form = QueryForm(model_to_dict(q))
         self.assertTrue(form.is_valid())
 
-    def test_form_fails_blacklist(self):
+    def test_form_is_invalid_with_non_select_statement(self):
         q = SimpleQueryFactory(sql="delete $$a$$;", created_by_user_id=None)
         q.params = {}
         form = QueryForm(model_to_dict(q))

--- a/explorer/utils.py
+++ b/explorer/utils.py
@@ -1,4 +1,3 @@
-import functools
 import re
 
 import sqlparse
@@ -10,16 +9,6 @@ from six import text_type
 from explorer import app_settings
 
 EXPLORER_PARAM_TOKEN = "$$"
-
-
-def passes_blacklist(sql):
-    clean = functools.reduce(
-        lambda sql, term: sql.upper().replace(term, ""),
-        [t.upper() for t in app_settings.EXPLORER_SQL_WHITELIST],
-        sql,
-    )
-    fails = [bl_word for bl_word in app_settings.EXPLORER_SQL_BLACKLIST if bl_word in clean.upper()]
-    return not any(fails), fails
 
 
 def _format_field(field):

--- a/explorer/views.py
+++ b/explorer/views.py
@@ -28,7 +28,7 @@ from explorer import app_settings, permissions
 from explorer.connections import connections
 from explorer.exporters import get_exporter_class
 from explorer.forms import QueryForm
-from explorer.models import FieldSchema, ModelSchema, MSG_FAILED_BLACKLIST, Query, QueryLog
+from explorer.models import FieldSchema, ModelSchema, Query, QueryLog
 from explorer.schema import schema_info
 from explorer.utils import (
     allowed_query_pks,
@@ -329,10 +329,8 @@ class PlayQueryView(PermissionRequiredMixin, ExplorerContextMixin, View):
         sql = request.POST.get('sql')
         show = url_get_show(request)
         query = Query(sql=sql, title="Playground", connection=request.POST.get('connection'))
-        passes_blacklist, failing_words = query.passes_blacklist()
-        error = MSG_FAILED_BLACKLIST % ', '.join(failing_words) if not passes_blacklist else None
-        run_query = not bool(error) if show else False
-        return self.render_with_sql(request, query, run_query=run_query, error=error)
+        run_query = True if show else False
+        return self.render_with_sql(request, query, run_query=run_query, error=None)
 
     def render(self):
         return self.render_template(


### PR DESCRIPTION
The blacklist check had too many edge cases so a simple validation to ensure the query starts with the word "SELECT" has been implemented. 

A desctructive query can still be executed by doing something like:

`SELECT * FROM foo;DROP TABLE bar;`

However, we prefer to let the user's database permissions govern what they can and can't do.