### PR TITLE
Add support for more field types

### DIFF
--- a/explorer/__init__.py
+++ b/explorer/__init__.py
@@ -1,4 +1,4 @@
-__version_info__ = {'major': 1, 'minor': 1, 'micro': 5, 'releaselevel': 'final', 'serial': 0}
+__version_info__ = {'major': 1, 'minor': 1, 'micro': 6, 'releaselevel': 'final', 'serial': 0}
 
 
 def get_version(short=False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ unicodecsv==0.14.1
 xlsxwriter==1.2.8
 django-celery==3.3.1
 factory-boy==2.12.0
+GeoAlchemy2==0.8.4
 dj-database-url==0.5.0
 django-environ==0.4.5
 psycopg2-binary==2.8.5


### PR DESCRIPTION
The schema panel was breaking in production because we have some
geometry fields, which sqlalchemy couldn't resolve. By adding the
GeoAlchemy2 package, SQLAlcehmy can resolve these and no longer errors.

In pursuit of this fix I noticed that a number of other relatively basic
fields weren't being resolved correctly, so have added those as well.