### PR TITLE
fix: show schema panel if no tables

### DIFF
--- a/explorer/__init__.py
+++ b/explorer/__init__.py
@@ -1,4 +1,4 @@
-__version_info__ = {'major': 1, 'minor': 1, 'micro': 6, 'releaselevel': 'final', 'serial': 0}
+__version_info__ = {'major': 1, 'minor': 1, 'micro': 7, 'releaselevel': 'final', 'serial': 0}
 
 
 def get_version(short=False):

--- a/explorer/views.py
+++ b/explorer/views.py
@@ -162,7 +162,7 @@ class SchemaView(PermissionRequiredMixin, View):
         if connection not in connections:
             raise Http404
         schema = schema_info(connection)
-        if schema:
+        if schema is not None:
             return render(None, 'explorer/schema.html', {'schema': schema_info(connection)})
         else:
             return render(None, 'explorer/schema_building.html')


### PR DESCRIPTION
If the user doesn't have access to any tables then the return value from
`schemas` is False-y, which ended up showing the "schema is building -
please wait" panel. This feels slightly misleading - we should show them
the schema panel - this feels more likely to get them to understand they
don't have access to any tables.